### PR TITLE
Draft: use require_relative instead of require

### DIFF
--- a/lib/binascii.rb
+++ b/lib/binascii.rb
@@ -1,9 +1,9 @@
-require 'binascii/qp'
-require 'binascii/uu'
-require 'binascii/base64'
-require 'binascii/hqx'
-require 'binascii/crc32'
-require 'binascii/hex'
+require_relative 'binascii/qp'
+require_relative 'binascii/uu'
+require_relative 'binascii/base64'
+require_relative 'binascii/hqx'
+require_relative 'binascii/crc32'
+require_relative 'binascii/hex'
 
 module Binascii
   include Qp

--- a/lib/binascii/qp.rb
+++ b/lib/binascii/qp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'binascii/utils'
+require_relative 'utils'
 
 module Binascii
   module Qp


### PR DESCRIPTION
It would be good to change this, I did minor testing locally but this probably should be tested.

When using this outside of gems, just manually importing binascii it will fail as the requires aren't relative to the base path.